### PR TITLE
column配列の添字が不適切な物だったため修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,41 +1,43 @@
 'use strict';
 const fs = require('fs');
 const readline = require('readline');
-const rs = fs.createReadStream('./popu-pref.csv');
+const rs = fs.ReadStream('./popu-pref.csv');
 const rl = readline.createInterface({ 'input': rs, 'output': {} });
+
 const prefectureDataMap = new Map(); // key: 都道府県 value: 集計データのオブジェクト
-rl.on('line', (lineString) => {
-  const columns = lineString.split(',');
-  const year = parseInt(columns[0]);
-  const prefecture = columns[1];
-  const popu = parseInt(columns[3]);
-  if (year === 2010 || year === 2015) {
-    let value = prefectureDataMap.get(prefecture);
-    if (!value) {
-      value = {
-        popu10: 0,
-        popu15: 0,
-        change: null
-      };
+rl.on('line', (line) => {
+    const columns = line.split(',');
+    const year = columns[0];
+    const prefecture = columns[2];
+    const popu = columns[7];
+    if (year === '2010' || year === '2015') {
+        let value = prefectureDataMap.get(prefecture);
+        if (!value) {
+            value = {
+                popu10: 0,
+                popu15: 0,
+                change: null
+            };
+        }
+        if (year === '2010') {
+            value.popu10 += parseInt(popu);
+        }
+        if (year === '2015') {
+            value.popu15 += parseInt(popu);
+        }
+        prefectureDataMap.set(prefecture, value);
     }
-    if (year === 2010) {
-      value.popu10 = popu;
-    }
-    if (year === 2015) {
-      value.popu15 = popu;
-    }
-    prefectureDataMap.set(prefecture, value);
-  }
 });
 rl.on('close', () => {
-  for (let [key, value] of prefectureDataMap) { 
-    value.change = value.popu15 / value.popu10;
-  }
-  const rankingArray = Array.from(prefectureDataMap).sort((pair1, pair2) => {
-    return pair2[1].change - pair1[1].change;
-  });
-  const rankingStrings = rankingArray.map(([key, value]) => {
-    return key + ': ' + value.popu10 + '=>' + value.popu15 + ' 変化率:' + value.change;
-  });
-  console.log(rankingStrings);
+    for (let [key, value] of prefectureDataMap) {
+        value.change = value.popu15 / value.popu10;
+    }
+    const rankingArray = Array.from(prefectureDataMap).sort((pair1, pair2) => {
+        return pair1[1].change - pair2[1].change;
+    });
+    const rankingStrings = rankingArray.map(([key, value],e) => {
+        return (e+1) + '位　' + key + ': ' + value.popu10 + '=>' + value.popu15 + ' 変化率:' + value.change;
+    });
+    console.log('   ・2010年から2015年にかけての15~19歳の人口推移ワーストランキング')
+    console.log(rankingStrings);
 });

--- a/app.js
+++ b/app.js
@@ -8,8 +8,8 @@ const prefectureDataMap = new Map(); // key: 都道府県 value: 集計データ
 rl.on('line', (line) => {
     const columns = line.split(',');
     const year = columns[0];
-    const prefecture = columns[2];
-    const popu = columns[7];
+    const prefecture = columns[1];
+    const popu = columns[3];
     if (year === '2010' || year === '2015') {
         let value = prefectureDataMap.get(prefecture);
         if (!value) {
@@ -20,24 +20,25 @@ rl.on('line', (line) => {
             };
         }
         if (year === '2010') {
-            value.popu10 += parseInt(popu);
+            value.popu10 = parseInt(popu);
         }
         if (year === '2015') {
-            value.popu15 += parseInt(popu);
+            value.popu15 = parseInt(popu);
         }
         prefectureDataMap.set(prefecture, value);
     }
 });
 rl.on('close', () => {
     for (let [key, value] of prefectureDataMap) {
-        value.change = value.popu15 / value.popu10;
+        value.change = (value.popu15*100) / value.popu10;
     }
     const rankingArray = Array.from(prefectureDataMap).sort((pair1, pair2) => {
-        return pair1[1].change - pair2[1].change;
+        return  pair1[1].change - pair2[1].change ;
     });
     const rankingStrings = rankingArray.map(([key, value],e) => {
-        return (e+1) + '位　' + key + ': ' + value.popu10 + '=>' + value.popu15 + ' 変化率:' + value.change;
+        return (e+1) + '位　' + key + ': ' + value.popu10 + '=>' + value.popu15 + ' 人 変化率:' + value.change + ' %';
     });
     console.log('   ・2010年から2015年にかけての15~19歳の人口推移ワーストランキング')
     console.log(rankingStrings);
+  
 });


### PR DESCRIPTION
10~12行目の変数に代入しているcolumn配列の添字が付属のcsvに適合しない[2]や[7]などになっていました。教材ページに記載がなかった&以前のコミット差分からみるに、おそらくcsvデータの簡素化の際にスクリプトの修正を忘れているのかと思われます。
